### PR TITLE
Adjusted image tags throughout tempalates to more suitable sizes

### DIFF
--- a/nurseconnect/templates/core/article_page.html
+++ b/nurseconnect/templates/core/article_page.html
@@ -12,7 +12,7 @@
             <header class="Paper-header">
 
                 {% if self.image %}
-                    {% image self.image max-500x150 class="Paper-graphic" %}
+                    {% image self.image width-320 class="Paper-graphic" %}
                 {% endif %}
 
                 <h1 class="Paper-headline">{{ self.title }}</h1>
@@ -30,7 +30,7 @@
                     {% elif block.block_type == "image" %}
                         {% if block.value %}
                             <figure>
-                                {% image block.value max-500x150 %}
+                                {% image block.value width-320 %}
                                 <figcaption>{{ block.value.title }}</figcaption>
                             </figure>
                         {% endif %}

--- a/nurseconnect/templates/core/section_page.html
+++ b/nurseconnect/templates/core/section_page.html
@@ -21,7 +21,7 @@
                     <article class="Article">
                         <a href="{% pageurl article %}" class="Article-hitBox">
                             {% if article.image %}
-                                {% image article.image width-100 class="Article-image Article-image--aside" %}
+                                {% image article.image width-85 class="Article-image Article-image--aside" %}
                             {% endif %}
                             <h2 class="Article-headline">{{ article.title }}</h2>
                             <p class="Article-strapline">{{ article.subtitle }}</p>

--- a/nurseconnect/templates/core/tags/latest_listing_homepage.html
+++ b/nurseconnect/templates/core/tags/latest_listing_homepage.html
@@ -10,7 +10,7 @@
                         <a href="{% pageurl article %}" class="Article-hitBox">
 
                             {% if article.image %}
-                                {% image article.image width-300 class="Article-image Article-image--aside" %}
+                                {% image article.image width-85 class="Article-image Article-image--aside" %}
                             {% endif %}
 
                             <h2 class="Article-headline">{{ article.title }}</h2>

--- a/nurseconnect/templates/core/tags/section_listing_menu.html
+++ b/nurseconnect/templates/core/tags/section_listing_menu.html
@@ -13,7 +13,7 @@
                     <li class="Menu-navItem" role="presentation">
                         <a href="{% url "home" %}" class="Menu-navLink" role="menuitem">
                             {% if section.image %}
-                                {% image section.image max-50x50 alt="" class="Menu-navIcon" %}
+                                {% image section.image width-85 alt="" class="Menu-navIcon" %}
                             {% endif %}
                             {{ section.title }}
                         </a>
@@ -22,7 +22,7 @@
                     <li class="Menu-navItem" role="presentation">
                         <a href="{% pageurl section %}" class="Menu-navLink" role="menuitem">
                             {% if section.image %}
-                                {% image section.image max-50x50 alt="" class="Menu-navIcon" %}
+                                {% image section.image width-85 alt="" class="Menu-navIcon" %}
                             {% endif %}
                             {{ section.title }}
                         </a>

--- a/nurseconnect/templates/core/tags/topic_of_the_day.html
+++ b/nurseconnect/templates/core/tags/topic_of_the_day.html
@@ -9,7 +9,7 @@
                     <a href="{% pageurl article %}" class="Article-hitBox">
 
                         {% if article.image %}
-                            {% image article.image width-300 class="Article-image Article-image--prominent" %}
+                            {% image article.image width-320 class="Article-image Article-image--prominent" %}
                         {% endif %}
 
                         <h2 class="Article-headline">{{ article.title }}</h2>


### PR DESCRIPTION
@chrislombaard @phalamag I have gone into the templates and tweaked the image sizes a bit. I'm hoping this fixes the current set of stretching and warping on the QA site.
