### PR TITLE
Change the placement of the Topic of the Day article

### DIFF
--- a/nurseconnect/templates/core/tags/latest_listing_homepage.html
+++ b/nurseconnect/templates/core/tags/latest_listing_homepage.html
@@ -4,8 +4,11 @@
 {% if articles %}
     <section class="ContentList">
         <div class="ContentList-body">
+            <header class="ContentList-header">
+                <h1 class="ContentList-categoryLabel">{% trans "Latest Articles" %}</h1>
+            </header>
             {% for article in articles %}
-                {% if forloop.counter <= 2 %}
+                {% if forloop.counter <= 3 %}
                     <article class="Article">
                         <a href="{% pageurl article %}" class="Article-hitBox">
 

--- a/nurseconnect/templates/core/tags/topic_of_the_day.html
+++ b/nurseconnect/templates/core/tags/topic_of_the_day.html
@@ -4,9 +4,6 @@
 
 <section class="ContentList">
     <div class="ContentList-body">
-        <header class="ContentList-header">
-            <h1 class="ContentList-categoryLabel">{% trans "Latest Articles" %}</h1>
-        </header>
         {% if articles %}
             {% for article in articles %}
                 <article class="Article Article--featured">


### PR DESCRIPTION
It is desired that the Topic of the Day article be placed
above the "Latest articles" heading. It is also desired that
there be three articles in the Latest section instead of two.
