### PR TITLE
NUR-108: Use molo.core version 3.11.1 to handle ordering of latest articles

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-molo.core==3.11.0
+molo.core==3.11.1
 molo.yourwords==1.0.2
 #molo.profiles
 molo.commenting==0.5.4


### PR DESCRIPTION
This latest release of molo.core made changes to how the demotion
of Topic of the day articles are handled. Upon demotion, the Topic
of the day article becomes the most recent article in the Latest
listing. Since Topic of the day articles' promotion can be
future-dated, it is then necessary to omit those future-dated
articles from the Latest articles listing.
