### PR TITLE
Allow for fake clinic code validation in dev environment

### DIFF
--- a/nurseconnect/settings/base.py
+++ b/nurseconnect/settings/base.py
@@ -342,6 +342,7 @@ LOGIN_URL = "auth_login"
 
 # For QA and production
 CLINIC_CODE_API = environ.get("CLINIC_CODE_API")
+FAKE_CLINIC_CODE_VALIDATION = False
 
 LOGIN_REDIRECT_URL = "/"
 

--- a/nurseconnect/settings/dev.py
+++ b/nurseconnect/settings/dev.py
@@ -16,6 +16,7 @@ EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 
 CLINIC_CODE_API = environ.get("CLINIC_CODE_API")
+FAKE_CLINIC_CODE_VALIDATION = True
 
 # JEMBI configuration
 JEMBI_URL = environ.get("JEMBI_URL")

--- a/nurseconnect/views.py
+++ b/nurseconnect/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.forms import ValidationError
 from django.contrib import messages
 from django.contrib.auth import authenticate, login
@@ -219,7 +220,11 @@ class RegistrationClinicCodeView(FormView):
 
     def form_valid(self, form):
         clinic_code = form.cleaned_data["clinic_code"]
-        clinic = get_clinic_code(clinic_code)
+
+        if settings.FAKE_CLINIC_CODE_VALIDATION and settings.DEBUG:
+            clinic = [0, 1, "fake_clinic_name"]
+        else:
+            clinic = get_clinic_code(clinic_code)
 
         if not clinic:
             form.add_error(


### PR DESCRIPTION
When creating a user, we require an external API call to confirm that the clinic code is valid and to return the clinic's name.
In a dev environment, to avoid further setup, by default we should be able to create users without settting up an external service

This PR adds the setting of FAKE_CLINIC_CODE_VALIDATION in a dev environment.
Faking of validation will only occur when both the FAKE_CLINIC_CODE_VALIDATION flag and DEBUG are set to True.