### PR TITLE
Feature/issue nur 474 fix external api call

### DIFF
--- a/nurseconnect/services.py
+++ b/nurseconnect/services.py
@@ -10,9 +10,10 @@ def get_clinic_code(clinic_code):
     if settings.FAKE_CLINIC_CODE_VALIDATION and settings.DEBUG:
         return [0, 1, "fake_clinic_name"]
 
-    url = settings.CLINIC_CODE_API
     try:
-        response = requests.get(url)
+        response = requests.get(
+            settings.CLINIC_CODE_API,
+            params={"criteria": "value:{}".format(clinic_code)})
     except requests.RequestException as e:
         logger.error("Error: {}".format(e))
         return None
@@ -26,9 +27,15 @@ def get_clinic_code(clinic_code):
             return None
 
         if data and ("rows" in data):
-            for clinic in data["rows"]:
-                if clinic_code == clinic[0]:
-                    return clinic
+            if len(data["rows"]) >= 1:
+                return data["rows"][0]
+            else:
+                return None
+        else:
+            logger.error(
+                "Returned data in unexpected format: {}".format(
+                    data if data is not None else "None"))
+            return None
     else:
         logger.error("Error: Status code {}".format(response.status_code))
     return None

--- a/nurseconnect/tests/test_services.py
+++ b/nurseconnect/tests/test_services.py
@@ -1,0 +1,95 @@
+import responses
+
+from django.test import TestCase, override_settings
+
+from nurseconnect.services import get_clinic_code
+
+FAKE_URL = "https://username:password@external.api/"
+
+FAKE_ENDPOINT_RESPONSE = {
+    "title": "Facility Check Nurse Connect",
+    "headers": [
+        {
+            "name": "value",
+            "column": "value",
+            "type": "java.lang.String",
+            "hidden": False,
+            "meta": False
+        },
+        {
+            "name": "uid",
+            "column": "uid",
+            "type": "java.lang.String",
+            "hidden": False,
+            "meta": False
+        },
+        {
+            "name": "name",
+            "column": "name",
+            "type": "java.lang.String",
+            "hidden": False,
+            "meta": False
+        }
+    ],
+    "rows": [
+        [
+            "123456",
+            "aTud78njasdf",
+            "NC Test Clinic"
+        ]
+    ],
+    "width": 3,
+    "height": 1
+}
+
+FAKE_ENDPOINT_INVALID_PARAM_RESPONSE = {
+    "title": "",
+    "headers": [],
+    "rows": [],
+    "width": 0,
+    "height": 0
+}
+
+
+@override_settings(CLINIC_CODE_API=FAKE_URL)
+class ServicesTestCase(TestCase):
+
+    @override_settings(FAKE_CLINIC_CODE_VALIDATION=True, DEBUG=True)
+    def test_get_clinic_code_returns_fake_data(self):
+        clinic_code = 123456
+
+        self.assertEqual(
+            get_clinic_code(clinic_code),
+            [0, 1, "fake_clinic_name"]
+        )
+
+    @responses.activate
+    def test_get_clinic_code_returns_none(self):
+        clinic_code = 123456
+        complete_url = "{}?criteria=value:{}".format(FAKE_URL, clinic_code)
+
+        responses.add(responses.GET, FAKE_URL, status=400)
+        self.assertEqual(get_clinic_code(clinic_code), None)
+
+        responses.add(responses.GET, FAKE_URL, status=200)
+        self.assertEqual(get_clinic_code(clinic_code), None)
+
+        responses.add(responses.GET, complete_url,
+                      json={'error': 'not found'}, status=200)
+        self.assertEqual(get_clinic_code(clinic_code), None)
+
+        responses.add(responses.GET, complete_url,
+                      json=FAKE_ENDPOINT_INVALID_PARAM_RESPONSE,
+                      status=200)
+        self.assertEqual(get_clinic_code(clinic_code), None)
+
+    @responses.activate
+    def test_get_clinic_code_returns_values(self):
+        clinic_code = 123456
+        complete_url = "{}?criteria=value:{}".format(FAKE_URL, clinic_code)
+
+        responses.add(responses.GET, complete_url,
+                      json=FAKE_ENDPOINT_RESPONSE, status=200)
+        self.assertEqual(
+            get_clinic_code(clinic_code),
+            FAKE_ENDPOINT_RESPONSE["rows"][0])


### PR DESCRIPTION
Related Ticket: https://praekeltorg.atlassian.net/browse/NUR-474

We were sending the external API a message to ask for a list of clinic codes and then checking whether the code was in that list of clinic codes. 
Instead we send a message which includes the clinic code, to check against that specific clinic.

This PR also adds tests for the entire `get_clinic_code`functionality as well as the changed functionality.