### PR TITLE
Update user sign-in button formatting on login page

### DIFF
--- a/nurseconnect/templates/core/home_page_before_login.html
+++ b/nurseconnect/templates/core/home_page_before_login.html
@@ -7,10 +7,10 @@
     <div class="Splash-actions">
         <ul class="ButtonGroup">
             <li class="ButtonGroup-item">
-                <a href="{% url "user_register" %}" class="Button">{% trans "Sign up now" %}</a>
+                <a href="{% url "auth_login" %}" class="Button">{% trans "Log In" %}</a>
             </li>
             <li class="ButtonGroup-item">
-                <a href="{% url "auth_login" %}" class="Button Button--inverted">{% trans "Log In" %}</a>
+                <a href="{% url "user_register" %}" class="Button Button--inverted">{% trans "Sign Up" %}</a>
             </li>
         </ul>
     </div>

--- a/nurseconnect/templates/registration/login.html
+++ b/nurseconnect/templates/registration/login.html
@@ -41,14 +41,16 @@
                 <div class="Splash-actions">
                     <ul class="ButtonGroup">
                         <li class="ButtonGroup-item">
-                            <input type="submit" class="Button" value="{% trans 'Sign in' %}">
+                            <input type="submit" class="Button" value="{% trans 'Log In' %}">
                             <input type="hidden" name="next" value="{% if request.GET.next %}{{ request.GET.next }}{% else %}{{ request.site.root_page.url }}{% endif %}"/>
                         </li>
                         <li class="ButtonGroup-item">
                             <div class="Message Message--subtle Message--centered">
                                 <p class="Message-caption">
-                                    {% trans "Don't have an account? Sign up" %} <a
-                                        href="{% url "user_register_msisdn" %}">{% trans "here" %}</a>
+                                    {% trans "Don't have an account?" %}
+                                    <li class="ButtonGroup-item">
+                                        <a href="{% url "user_register" %}" class="Button Button--inverted">{% trans "Sign Up" %}</a>
+                                    </li>
                                 </p>
                                 <a href="{% url "forgot_password" %}" class="Link">{% trans "Forgot password? Click here." %}</a>
                             </div>


### PR DESCRIPTION
Old Screens:
<img width="635" alt="screen shot 2018-05-24 at 12 20 17" src="https://user-images.githubusercontent.com/7100966/40544272-005fa92a-6028-11e8-950d-3d9d1d835b09.png">
<img width="637" alt="screen shot 2018-05-24 at 12 19 36" src="https://user-images.githubusercontent.com/7100966/40544274-00b11dc8-6028-11e8-81b5-cc9d631a3161.png">

This PR makes the action buttons more consistent and visibly styled for the user