### PR TITLE
ensure that the search bar only appears when the user clicks on it

### DIFF
--- a/nurseconnect/templates/base.html
+++ b/nurseconnect/templates/base.html
@@ -124,8 +124,8 @@
                             </li>
                         {% endfor %}
                         <li class="static-menu-list__item">
-                           <a href="{% if request.path == "/" %}#search{% else %}{% url "search" %}{% endif %}" id="NavBar__search" class="static-menu-list__anchor">
-                             {% trans "Search" %}
+                           <a href="{% url "search" %}" id="NavBar__search" class="static-menu-list__anchor">
+                             {% trans "Searchs" %}
                            </a>
                        </li>
                        {% if user.is_authenticated %}

--- a/nurseconnect/templates/core/header.html
+++ b/nurseconnect/templates/core/header.html
@@ -16,7 +16,7 @@
                     </li>
                     <li class="NavBar-navItem{% if active == "search" %} NavBar-navItem--search {% if search_results %}NavBar-navItem--searchResults{% endif %} NavBar-navItem--active{% endif %}"
                         role="presentation">
-                          <a href="{% if request.path == "/" %}#search{% else %}{% url "search" %}{% endif %}" class="NavBar-navLink" id="NavBar__search" role="menuitem">
+                          <a href="{% url "search" %}" class="NavBar-navLink" id="NavBar__search" role="menuitem">
                             {% trans "Search" %}
                           </a>
                     </li>

--- a/nurseconnect/templates/core/main.html
+++ b/nurseconnect/templates/core/main.html
@@ -11,7 +11,6 @@
             </div>
           </section>
       {% endif %}
-      {{request.resolver_match.url_name }}
     {% if request.path == 'search' %}
     {% block search %}
       {% include "core/search-form.html" with id="search" %}

--- a/nurseconnect/templates/core/main.html
+++ b/nurseconnect/templates/core/main.html
@@ -11,9 +11,12 @@
             </div>
           </section>
       {% endif %}
+      {{request.resolver_match.url_name }}
+    {% if request.path == 'search' %}
     {% block search %}
       {% include "core/search-form.html" with id="search" %}
     {% endblock %}
+    {% endif %}
     {% topic_of_the_day %}
     {% latest_listing_homepage num_count=6 %}
     {% include "core/learn-banner.html" %}

--- a/nurseconnect/tests/test_views.py
+++ b/nurseconnect/tests/test_views.py
@@ -27,7 +27,7 @@ class MenuTestCase(MoloTestCaseMixin, TestCase):
         self.assertEqual(response.status_code, 200)
 
 
-class MenuSearchCase(MoloTestCaseMixin, TestCase):
+class SearchTestCase(MoloTestCaseMixin, TestCase):
     def setUp(self):
         self.mk_main()
         self.client = Client()

--- a/nurseconnect/tests/test_views.py
+++ b/nurseconnect/tests/test_views.py
@@ -42,7 +42,7 @@ class SearchTestCase(MoloTestCaseMixin, TestCase):
     def test_search_view(self):
         # Test that the search only occurs when the user clicks on t
         response = self.client.get(reverse("search"))
-        self.assertNotContains(response, 'What are you looking for?')
+        self.assertContains(response, 'What are you looking for?')
         self.assertContains(response, 'Search')
 
 

--- a/nurseconnect/tests/test_views.py
+++ b/nurseconnect/tests/test_views.py
@@ -27,6 +27,25 @@ class MenuTestCase(MoloTestCaseMixin, TestCase):
         self.assertEqual(response.status_code, 200)
 
 
+class MenuSearchCase(MoloTestCaseMixin, TestCase):
+    def setUp(self):
+        self.mk_main()
+        self.client = Client()
+
+    def test_search_on_homepage(self):
+        # Test that the search only occurs when the user clicks on t
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'What are you looking for?')
+        self.assertContains(response, 'Search')
+
+    def test_search_view(self):
+        # Test that the search only occurs when the user clicks on t
+        response = self.client.get(reverse("search"))
+        self.assertNotContains(response, 'What are you looking for?')
+        self.assertContains(response, 'Search')
+
+
 class RegistrationViewTestCase(MoloTestCaseMixin, TestCase):
     def setUp(self):
         self.mk_main()


### PR DESCRIPTION
The search bar is showing by default for the users and ideally we want it to only show up when the user clicks on it. It is taking up too much space in the home view

Home view after this PR's changes
![image](https://user-images.githubusercontent.com/9092348/52704343-fee52a80-2f88-11e9-8062-a14d2b840fc0.png)
