### PR TITLE
git remove all images from the menu view

### DIFF
--- a/nurseconnect/templates/core/tags/section_listing_menu.html
+++ b/nurseconnect/templates/core/tags/section_listing_menu.html
@@ -10,30 +10,23 @@
     <ul class="Menu-navGroup Menu-navGroup--lvl1" role="menu">
       <li class="Menu-navItem" role="presentation">
         <a href="{% url "home" %}" class="Menu-navLink" role="menuitem">
-          <img alt="Home" src="{% static "dist/icons/png/clinic-bluePelorous.png" %}" class="Menu-navIcon">
           {% trans "Home" %}
         </a>
       </li>
     {% for section in sections %}
         <li class="Menu-navItem" role="presentation">
           <a href="{% pageurl section %}" class="Menu-navLink" role="menuitem">
-            {% if section.image %}
-              {% image section.image width-40 as imagePath %}
-              <img alt="{{section.title}}" src="{{imagePath.url}}" class="Menu-navIcon">
-            {% endif %}
             {{ section.title }}
           </a>
         </li>
     {% endfor %}
       <li class="Menu-navItem" role="presentation">
         <a href="{% url "search" %}" class="Menu-navLink" role="menuitem">
-          <img alt="Search" src="{% static "dist/icons/png/search-bluePelorous.png" %}" class="Menu-navIcon">
             {% trans "Search" %}
         </a>
       </li>
       <li class="Menu-navItem" role="presentation">
         <a href="{% url 'molo.profiles:view_my_profile' %}" class="Menu-navLink" role="menuitem">
-          <img alt="Profile" src="{% static "dist/icons/png/profile-bluePelorous.png" %}" class="Menu-navIcon">
           {% trans "Your Profile" %}
         </a>
       </li>


### PR DESCRIPTION
Whenever an icon needs to be created Praekelt has to source a design studio to do it. This can be expensive and time-consuming. Icons help give a visual cue for the category but when weighed up against time and expenses it can be removed. Because of this, there are currently some sections without icons and the icons are mismatched in size.

![image](https://user-images.githubusercontent.com/9092348/52709688-1d9dee00-2f96-11e9-8ae4-a3c373c80412.png)
